### PR TITLE
Fix YAML syntax error in update-formula workflow

### DIFF
--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -145,14 +145,17 @@ jobs:
         fi
         
         # Commit changes
-        git commit -m "Update aicm to v${VERSION}
-
-- Update all platform binaries to v${VERSION}
-- Update SHA256 hashes for all supported platforms
-- Update version in test assertion
-- Remove bottle section for new version
-
-🤖 Generated with GitHub Actions"
+        git commit -m "$(cat <<EOF
+        Update aicm to v${VERSION}
+        
+        - Update all platform binaries to v${VERSION}
+        - Update SHA256 hashes for all supported platforms
+        - Update version in test assertion
+        - Remove bottle section for new version
+        
+        🤖 Generated with GitHub Actions
+        EOF
+        )"
 
     - name: Push branch and create PR
       env:


### PR DESCRIPTION
## Summary
- Fix YAML syntax error on line 149 in update-formula.yml workflow
- Replace problematic multi-line commit message with HEREDOC format
- Ensures proper string handling in GitHub Actions environment

## Problem
The workflow had invalid YAML syntax where the multi-line commit message was not properly formatted, causing GitHub Actions to fail validation.

## Solution
- Changed from direct multi-line string to HEREDOC format using `cat <<EOF`
- This approach is more robust for complex commit messages with newlines
- Maintains the same commit message content while fixing syntax

## Test plan
- [x] Fixed YAML syntax error
- [x] Verified proper HEREDOC format
- [x] Maintained original commit message structure

🤖 Generated with [Claude Code](https://claude.ai/code)