### PR TITLE
aicm 0.2.0

### DIFF
--- a/Formula/aicm.rb
+++ b/Formula/aicm.rb
@@ -5,29 +5,29 @@ class Aicm < Formula
 
   on_macos do
     on_arm do
-      url     "https://github.com/morooka-akira/aicm/releases/download/v0.1.3/aicm-aarch64-apple-darwin",
+      url     "https://github.com/morooka-akira/aicm/releases/download/v0.2.0/aicm-aarch64-apple-darwin",
               using: :nounzip
-      sha256  "126974ac18d980030696a427be2056b509021963a33696d6142f86b363f77068"
+      sha256  "95aa6c09a087ba08e037a1e1e6f15c68e9f9ebbd6e87bd195fd28247c6c428d9"
     end
 
     on_intel do
-      url     "https://github.com/morooka-akira/aicm/releases/download/v0.1.3/aicm-x86_64-apple-darwin",
+      url     "https://github.com/morooka-akira/aicm/releases/download/v0.2.0/aicm-x86_64-apple-darwin",
               using: :nounzip
-      sha256  "338451cbc2a6f8fbcee2fe435a19163e4fdc9fd08fed47b4474c4c1c6353b8d4"
+      sha256  "3576f464e8e5887c568c9b545d0da8d957e24f371cec642ad7e58c7a15760f17"
     end
   end
 
   on_linux do
     on_intel do
-      url     "https://github.com/morooka-akira/aicm/releases/download/v0.1.3/aicm-x86_64-unknown-linux-gnu",
+      url     "https://github.com/morooka-akira/aicm/releases/download/v0.2.0/aicm-x86_64-unknown-linux-gnu",
               using: :nounzip
-      sha256  "cd307e9e3f8f2ef8d213013b14505200d2f8492bbfefb4f1e1d83b84142705a2"
+      sha256  "24408ad8ca78392f7c374a732e571e6f3a2a0d46f1f64f306a5b32714506f214"
     end
 
     on_arm do
-      url     "https://github.com/morooka-akira/aicm/releases/download/v0.1.3/aicm-aarch64-unknown-linux-gnu",
+      url     "https://github.com/morooka-akira/aicm/releases/download/v0.2.0/aicm-aarch64-unknown-linux-gnu",
               using: :nounzip
-      sha256  "055cff13fd4db4cc63f6afcba656f68b6999edcb820845c16f545e9b2813165d"
+      sha256  "0ddbf37425f619f292e3989ba87eb45ef3846be9620a1e040adde6c1088f69b5"
     end
   end
 
@@ -38,6 +38,6 @@ class Aicm < Formula
   end
 
   test do
-    assert_match "0.1.3", shell_output("#{bin}/aicm --version")
+    assert_match "0.2.0", shell_output("#{bin}/aicm --version")
   end
 end


### PR DESCRIPTION
## Summary
- Update aicm formula from v0.1.3 to v0.2.0
- Update SHA256 hashes for all 4 platforms (macOS ARM64/Intel, Linux x86_64/ARM64)
- Update version assertion in test block

## Test plan
- [ ] Verify formula style with `brew style morooka-akira/aicm`
- [ ] Verify formula audit with `brew audit --except=installed --tap=morooka-akira/aicm`
- [ ] Verify syntax with `brew readall --aliases --os=all --arch=all morooka-akira/aicm`
- [ ] Test installation on available platforms

🤖 Generated with [Claude Code](https://claude.ai/code)